### PR TITLE
Add sniffer

### DIFF
--- a/p5.packets-server/sniff.py
+++ b/p5.packets-server/sniff.py
@@ -1,5 +1,4 @@
 from scapy.all import *
-import argparse
 import sys
 
 def get_interface():


### PR DESCRIPTION
- get network interface based on sys.platform
- create default sniffer config that can be changed by passing in a dict like { 'key': value } to get_sniffer_config(), where key and value are acceptable sniff() parameters (defined by scapy)
- close #4 